### PR TITLE
Version 4.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Version 4.9.5
+
+🐛 Bug Fix
+
+- Resetting encounters also resets badges now
+- Added Pewter City as a location in Red, Blue, and Yellow
+- Added Zubat and Golbat to Iron Island encounters in BDSP
+- Fixed Cranidos' level in Diamond, Pearl, and Platinum
+
 ## Version 4.9.4
 
 🐛 Bug Fix

--- a/cypress/.eslintrc.json
+++ b/cypress/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "parserOptions": {
+    "tsconfigRootDir": "__dirname",
+    "project": "./tsconfig.json"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuzlocke",
   "author": "Diego Ballesteros Castellanos",
   "description": "Nuzlocke tracker to record encounters with detailed information",
-  "version": "4.9.4",
+  "version": "4.9.5",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/diballesteros/nuzlocke/issues"

--- a/src/constants/changelog.ts
+++ b/src/constants/changelog.ts
@@ -2,6 +2,29 @@ import type { TReleaseNotes } from 'constants/types';
 
 const CHANGELOG: TReleaseNotes = [
   {
+    name: 'Version 4.9.5',
+    date: 1649374478404,
+    notes: [
+      {
+        description: 'Resetting encounters also resets badges now',
+        type: 'FIX',
+      },
+      {
+        description:
+          'Added Pewter City as a location in Red, Blue, and Yellow (requires a reset to encounters to see)',
+        type: 'FIX',
+      },
+      {
+        description: 'Added Zubat and Golbat to Iron Island encounters in BDSP',
+        type: 'FIX',
+      },
+      {
+        description: "Fixed Cranidos' level in Diamond, Pearl, and Platinum",
+        type: 'FIX',
+      },
+    ],
+  },
+  {
     name: 'Version 4.9.4',
     date: 1648869568970,
     notes: [

--- a/src/constants/details.ts
+++ b/src/constants/details.ts
@@ -2703,7 +2703,7 @@ const DETAILS: { [key: string]: TDetail[][] } = {
           {
             ability: 'Mold Breaker',
             id: 408,
-            level: 12,
+            level: 14,
             moves: [29, 43, 228],
           },
         ],

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -472,6 +472,7 @@ const FILTERS: { [key in string]: string[] } = {
     'Ditto',
     'Mewtwo',
   ],
+  'rby-49': [],
   'gsc-0': ['Cyndaquil', 'Chikorita', 'Totodile'],
   'gsc-1': [
     'Tentacool',
@@ -8067,6 +8068,8 @@ const FILTERS: { [key in string]: string[] } = {
     'Onix',
     'Steelix',
     'Riolu',
+    'Zubat',
+    'Golbat',
   ],
   'bdsp-48': [
     'Psyduck',

--- a/src/constants/locations/R_B_Y.ts
+++ b/src/constants/locations/R_B_Y.ts
@@ -51,6 +51,13 @@ const R_B_Y: TEncounter[] = [
     filterKey: 'rby-6',
   },
   {
+    id: 7,
+    pokemon: null,
+    location: 'Pewter City',
+    status: null,
+    filterKey: 'rby-49',
+  },
+  {
     id: 8,
     pokemon: null,
     location: 'Route 3',

--- a/src/locale/de/tracker.json
+++ b/src/locale/de/tracker.json
@@ -28,7 +28,7 @@
   "pokemon_export": "Pokémon erfolgreich exportiert",
   "reset": "ZURÜCKSETZEN",
   "reset_2": "Zurücksetzen",
-  "reset_confirm": "Dadurch werden alle Begegnungen für das ausgewählte Spiel zurückgesetzt und benutzerdefinierte Begegnungen gelöscht. Bist du sicher?",
+  "reset_confirm": "Dadurch werden alle Begegnungen für das ausgewählte Spiel zurückgesetzt, benutzerdefinierte Begegnungen gelöscht und die Markierung aller Abzeichen aufgehoben. Bist du sicher?",
   "reset_encounters": "Begegnungen zurücksetzen",
   "reset_success": "Begegnungen wurden erfolgreich zurückgesetzt",
   "share": "Teilen"

--- a/src/locale/en/tracker.json
+++ b/src/locale/en/tracker.json
@@ -28,7 +28,7 @@
   "pokemon_export": "Pokémon successfully exported",
   "reset": "RESET",
   "reset_2": "Reset",
-  "reset_confirm": " This will reset all encounters for the selected game and delete custom encounters. Are you sure?",
+  "reset_confirm": "This will reset all encounters for the selected game, delete custom encounters, and unmark all badges. Are you sure?",
   "reset_encounters": "Reset Encounters ",
   "reset_success": "Successfully reset encounters",
   "share": "Share"

--- a/src/locale/es/tracker.json
+++ b/src/locale/es/tracker.json
@@ -28,7 +28,7 @@
   "pokemon_export": "Pokémon exportado con éxito",
   "reset": "RESETEAR",
   "reset_2": "Resetear",
-  "reset_confirm": "Esto restablecerá todos los encuentros del juego seleccionado y eliminará los encuentros personalizados. ¿Está seguro?",
+  "reset_confirm": "Esto restablecerá todos los encuentros para el juego seleccionado, eliminará los encuentros personalizados y desmarcará todas las insignias. ¿Está seguro?",
   "reset_encounters": "Restablecer encuentros",
   "reset_success": "Los encuentros se restablecieron con éxito",
   "share": "Compartir"

--- a/src/store.ts
+++ b/src/store.ts
@@ -446,6 +446,7 @@ const useStore = create<AppState>(
           ]?.encounters
             ? INITIAL_STATE.games[state.selectedGame.value].encounters
             : [];
+          state.games[state.selectedGame?.value].badge = [];
         }),
       resetBadges: (gameKey: string) =>
         set((state) => {


### PR DESCRIPTION
# Description

- Resetting encounters also resets badges now
- Added Pewter City as a location in Red, Blue, and Yellow
- Added Zubat and Golbat to Iron Island encounters in BDSP
- Fixed Cranidos' level in Diamond, Pearl, and Platinum
- 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
